### PR TITLE
Add node raises more user-friendly exception

### DIFF
--- a/elfi/graph.py
+++ b/elfi/graph.py
@@ -17,8 +17,15 @@ class Graph:
     def add_node(self, node):
         if node not in self.nodes.values():
             if node.name in self.nodes:
-                raise ValueError('Node name {} is already in use'.format(node.name))
-            self.nodes[node.name] = node
+                msg = "\n\n" + "*" * 80 + "\n" + \
+                      "A node with the name '{}' is already in use in the current Inference Task.\n" \
+                      "If you really want to overwrite the old node, either:\n" \
+                      "a) use the node's 'redefine' method, or\n" \
+                      "b) start a new Inference Task with elfi.env.new_inference_task().".format(node.name) \
+                      + "\n" + "*" * 80 + "\n"
+                raise SystemExit(msg)
+            else:
+                self.nodes[node.name] = node
 
     def remove_node(self, node):
         if node.name in self.nodes:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -94,7 +94,7 @@ def test_generate_vs_acquire():
 
 def test_same_key_error():
     elfi.Transform('op', lambda _:_)
-    with pytest.raises(Exception) as e:
+    with pytest.raises(SystemExit) as e:
         elfi.Transform('op', lambda _:_)
 
 


### PR DESCRIPTION
#### Summary:
When user tries to add a node with a pre-existing name, a SystemExit is raised and the user is given suggestions on what to do.

#### Intended Effect:
Raise exception with message and short traceback.

#### How to Verify:
Try to create a node with a pre-existing name.

#### Side Effects:
None.

#### Documentation:
Not applicable.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
