### PR TITLE
Fixed problem with __repl__ with Distribution by adding a name property

### DIFF
--- a/elfi/distributions.py
+++ b/elfi/distributions.py
@@ -34,7 +34,7 @@ class Distribution:
 
     @property
     def name(self):
-        return self._name or self.__class__.__name__
+        return self._name or Distribution.__class__.__name__
 
 
 # TODO: this might be needed for rv_discrete instances in the future?

--- a/elfi/distributions.py
+++ b/elfi/distributions.py
@@ -21,7 +21,7 @@ class Distribution:
     """
 
     def __init__(self, name=None):
-        self.name = name
+        self._name = name or self.__class__.__name__
 
     def rvs(self, *params, size=(1,), random_state):
         raise NotImplementedError
@@ -31,6 +31,10 @@ class Distribution:
 
     def logpdf(self, x, *params, **kwargs):
         raise NotImplementedError
+
+    @property
+    def name(self):
+        return self._name or self.__class__.__name__
 
 
 # TODO: this might be needed for rv_discrete instances in the future?


### PR DESCRIPTION
#### Summary:
Added property name to Distribution class to allow its calling for static classes, whose constructor has not been called.

#### Intended Effect:
No more crashing after calling __repl__ for custom distributions.

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

