### PR TITLE
Set tornado's logLevel to warning.

### DIFF
--- a/elfi/env.py
+++ b/elfi/env.py
@@ -1,11 +1,14 @@
 from collections import defaultdict
 import socket
+import logging
 
 from distributed import Client, LocalCluster
 from elfi.inference_task import InferenceTask
 
 _globals = defaultdict(lambda: None)
 _whitelist = ["client", "inference_task"]
+
+logging.getLogger('tornado').setLevel(logging.WARNING)
 
 
 def set_option(**kwargs):

--- a/elfi/env.py
+++ b/elfi/env.py
@@ -5,10 +5,11 @@ import logging
 from distributed import Client, LocalCluster
 from elfi.inference_task import InferenceTask
 
-_globals = defaultdict(lambda: None)
-_whitelist = ["client", "inference_task"]
 
 logging.getLogger('tornado').setLevel(logging.WARNING)
+
+_globals = defaultdict(lambda: None)
+_whitelist = ["client", "inference_task"]
 
 
 def set_option(**kwargs):


### PR DESCRIPTION
#### Summary:
Set tornado's logLevel to warning.

#### Intended Effect:
Nicer terminal output.

#### How to Verify:
The appearance of INFO messages appeared somewhat inconsistent, so nontrivial.

#### Side Effects:
-
#### Documentation:
-
#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
