### PR TITLE
Distributed 1.15.x compatibility fix

### DIFF
--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -2,7 +2,7 @@
 from elfi.core import Transform, Simulator, Summary, Discrepancy
 from elfi.distributions import *
 from elfi.methods import *
-from elfi.storage import *
+from elfi.store import *
 from elfi.visualization import *
 from elfi.inference_task import InferenceTask
 from elfi.env import client, inference_task, new_inference_task

--- a/elfi/async.py
+++ b/elfi/async.py
@@ -46,3 +46,15 @@ def next_result(futures):
             del futures[i]
             return f.result(), i
     return None, None
+
+
+def add_done_callback(future, callback):
+    """
+    Runs the callback in the main thread using the Tornado event loop.
+
+    Use this instead of `future.add_done_callback` when you want the callback to be run
+    immediately when the result becomes available. This was the behaviour of
+    dask.distributed 1.13. The behaviour changed in 1.15.
+    """
+
+    future.client.loop.add_callback(dc.done_callback, future, callback)

--- a/elfi/core.py
+++ b/elfi/core.py
@@ -4,7 +4,7 @@ from functools import partial
 import numpy as np
 
 from elfi.utils import *
-from elfi.storage import ElfiStore, LocalDataStore, MemoryStore
+from elfi.store import ElfiStore, LocalDataStore, MemoryStore
 from elfi.graph import Node
 from elfi import env
 

--- a/elfi/methods.py
+++ b/elfi/methods.py
@@ -344,8 +344,7 @@ class SMC(ABCMethod):
 
         # Build the SMC proposal
         q = SMCProposal(np.hstack(samples), weights)
-        qnode = Prior("smc_proposal", q,
-                      size=(q.size),
+        qnode = Prior("smc_proposal", q, size=q.size,
                       inference_task=self.distance_node.inference_task)
 
         # Connect the proposal to the graph

--- a/elfi/methods.py
+++ b/elfi/methods.py
@@ -3,7 +3,6 @@ from functools import partial
 
 import numpy as np
 import dask
-from distributed import Client
 
 from elfi import core
 from elfi import Discrepancy, Transform
@@ -539,7 +538,7 @@ class BOLFI(ABCMethod):
         else:
             logger.debug("{}: No dask client given, creating a local client."
                     .format(self.__class__.__name__))
-            self.client = Client()
+            self.client = elfi_client()
             dask.set_options(get=self.client.get)
 
         if self.store is not None:

--- a/elfi/methods.py
+++ b/elfi/methods.py
@@ -6,7 +6,7 @@ import dask
 
 from elfi import core
 from elfi import Discrepancy, Transform
-from elfi import storage
+from elfi.store import NameIndexDataInterface
 from elfi.async import wait, next_result
 from elfi.env import client as elfi_client
 from elfi.distributions import Prior, SMCProposal
@@ -541,7 +541,7 @@ class BOLFI(ABCMethod):
             dask.set_options(get=self.client.get)
 
         if self.store is not None:
-            if not isinstance(self.store, storage.NameIndexDataInterface):
+            if not isinstance(self.store, NameIndexDataInterface):
                 raise ValueError("Expected storage object to fulfill NameIndexDataInterface")
             self.sample_idx = 0
             self._log_model()

--- a/elfi/store.py
+++ b/elfi/store.py
@@ -14,6 +14,7 @@ from dask.delayed import delayed
 from tornado import gen
 
 from elfi.utils import to_slice, get_key_slice, get_key_id, get_named_item, make_key
+from elfi.async import add_done_callback
 import elfi.env as env
 
 from unqlite import UnQLite
@@ -133,7 +134,7 @@ class LocalElfiStore(ElfiStore):
         self._pending_persisted[key] = d
         # Take out the underlying future
         future = d.dask[key]
-        future.add_done_callback(lambda f: self._post_task(key, f, done_callback))
+        add_done_callback(future, lambda f: self._post_task(key, f, done_callback))
 
     def read_data(self, node_id, sl):
         data_id = node_id + "-data"

--- a/elfi/store.py
+++ b/elfi/store.py
@@ -175,7 +175,7 @@ class MemoryStore(ElfiStore):
 
         future = d.dask[key]
         if done_callback is not None:
-            future.add_done_callback(lambda f: done_callback(key, f))
+            add_done_callback(future, lambda f: done_callback(key, f))
 
     def read(self, key):
         return self._persisted[key].compute()

--- a/tests/unit/test_methods.py
+++ b/tests/unit/test_methods.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 import elfi
-from elfi.storage import DictListStore
+from elfi.store import DictListStore
 
 
 class TestSMCDistribution():

--- a/tests/unit/test_methods.py
+++ b/tests/unit/test_methods.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 
 import elfi
-from elfi import weighted_cov
 from elfi.storage import DictListStore
 
 
@@ -178,6 +177,8 @@ class TestRejection(MockModel):
 class TestBOLFI(MockModel):
 
     def set_basic_bolfi(self):
+        # Restrict the number of workers
+        elfi.env.client(n_workers=4, threads_per_worker=1)
         self.n_sim = 4
         self.n_batch = 2
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2,8 +2,8 @@ import os
 
 from test_core_persistence import TestPersistence
 
-from elfi.storage import UnQLiteDatabase
-from elfi.storage import DictListStore
+from elfi.store import UnQLiteDatabase
+from elfi.store import DictListStore
 
 
 def database_read_write_test(db):


### PR DESCRIPTION
Work in progress. Build fails with Distributed 1.15.x are probably caused by their change of running the callback for `Future.add_done_callback` in a separate thread.

> `Future.add_done_callback` executes in separate thread #656